### PR TITLE
Upgrade surro-gate to 1.0.4

### DIFF
--- a/server/purr.gemspec
+++ b/server/purr.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'rack', '~> 2.0.0'
-  spec.add_dependency 'surro-gate', '~> 0.1.1'
+  spec.add_dependency 'surro-gate', '~> 1.0.4'
 
   spec.add_development_dependency 'bundler', '~> 1.13'
   spec.add_development_dependency 'codecov', '~> 0.1.0'


### PR DESCRIPTION
The latest version of [surro-gate](https://rubygems.org/gems/surro-gate) finally implements a spinlock-free selector.